### PR TITLE
fix: install mrboom addon to correct directory

### DIFF
--- a/addons/game.libretro.mrboom/game.libretro.mrboom.json
+++ b/addons/game.libretro.mrboom/game.libretro.mrboom.json
@@ -7,8 +7,7 @@
         "cxxflags": "-g0"
     },
     "config-opts": [
-        "-DCMAKE_BUILD_TYPE=Release",
-        "-DOVERRIDE_PATHS=ON"
+        "-DCMAKE_BUILD_TYPE=Release"
     ],
     "sources": [
         {


### PR DESCRIPTION
## Summary
- ensure mrboom libretro addon installs under `/app/lib/kodi/addons`

## Testing
- `flatpak-builder --force-clean --stop-at=game.libretro.mrboom build-dir tv.kodi.Kodi.yml` *(fails: `org.freedesktop.Sdk/x86_64/24.08 not installed`)*
- `flatpak --user --noninteractive install flathub org.freedesktop.Sdk//24.08` *(fails: `bwrap: Creating new namespace failed: Operation not permitted`)*

------
https://chatgpt.com/codex/tasks/task_e_68901a147b688326ab25cf5299f8b349